### PR TITLE
Fix filters for numeric values, add urlized, add contains string support

### DIFF
--- a/service/support/filter-parser.js
+++ b/service/support/filter-parser.js
@@ -38,11 +38,15 @@ const parseInternal = filter => {
       return `${filter.fieldName} >= ${mysql.escape(mapValue(filter.value))}`
     case '$hasSome':
     case '$contains': {
-      const list = filter.value
-        .map(mapValue)
-        .map(date => mysql.escape(date, null, null))
-        .join(', ')
-      return list ? `${filter.fieldName} IN (${list})` : EMPTY
+      if (typeof filter.value === 'string') {
+        return `${filter.fieldName} LIKE ${mysql.escape(`%${filter.value}%`)}`
+      } else {
+        const list = filter.value
+          .map(mapValue)
+          .map(date => mysql.escape(date, null, null))
+          .join(', ')
+        return list ? `${filter.fieldName} IN (${list})` : EMPTY
+      }
     }
     case '$urlized': {
       const list = filter.value.map(s => s.toLowerCase()).join('[- ]')
@@ -65,5 +69,7 @@ const parseInternal = filter => {
 }
 
 const mapValue = value => {
-  return Date.parse(value) ? new Date(value) : value
+  return typeof value === 'string' && Date.parse(value)
+    ? new Date(value)
+    : value
 }

--- a/service/support/filter-parser.spec.js
+++ b/service/support/filter-parser.spec.js
@@ -277,6 +277,19 @@ describe('Filter Parser', () => {
       assert.equal(result, "WHERE foo >= 'bar'")
     })
 
+    it('does not convert numeric value to date', async () => {
+      const filter = {
+        kind: 'filter',
+        operator: '$gte',
+        fieldName: 'foo',
+        value: 123
+      }
+
+      const result = parseFilter(filter)
+
+      assert.equal(result, 'WHERE foo >= 123')
+    })
+
     it('handles gte filter with date', async () => {
       const date = new Date()
       const dateIso = date.toISOString()
@@ -333,7 +346,7 @@ describe('Filter Parser', () => {
       assert.equal(result, `WHERE foo IN (${mysql.escape(date)})`)
     })
 
-    it('handles contains filter', async () => {
+    it('handles contains filter with array valuie', async () => {
       const filter = {
         kind: 'filter',
         operator: '$contains',
@@ -344,6 +357,19 @@ describe('Filter Parser', () => {
       const result = parseFilter(filter)
 
       assert.equal(result, "WHERE foo IN ('bar', 'baz')")
+    })
+
+    it('handles contains filter with string value', async () => {
+      const filter = {
+        kind: 'filter',
+        operator: '$contains',
+        fieldName: 'foo',
+        value: 'bar'
+      }
+
+      const result = parseFilter(filter)
+
+      assert.equal(result, "WHERE foo LIKE '%bar%'")
     })
 
     it('handles contains filter with date', async () => {

--- a/service/support/table-converter.js
+++ b/service/support/table-converter.js
@@ -29,7 +29,8 @@ const convertFields = columns => {
           'not',
           'ne',
           'startsWith',
-          'endsWith'
+          'endsWith',
+          'urlized'
         ]
       }
     })

--- a/service/support/table-converter.spec.js
+++ b/service/support/table-converter.spec.js
@@ -14,7 +14,8 @@ const supportedOperators = [
   'not',
   'ne',
   'startsWith',
-  'endsWith'
+  'endsWith',
+  'urlized'
 ]
 
 const aTable = (...columns) => {

--- a/utils/error-middleware.js
+++ b/utils/error-middleware.js
@@ -13,6 +13,8 @@ exports.wrapError = fn => (req, res, next) => {
 }
 
 exports.errorMiddleware = (err, req, res, next) => {
+  console.log(err.message)
+
   switch (err.constructor.name) {
     case BadRequestError.name:
       res.status(400).send({ message: err.message })


### PR DESCRIPTION
Filters with numeric values were incorrect converted to dates, therefore filtering was not working as expected.
Added urlized filter to supported filters, since implementation supports it.
Added support for contains filter with a string value.

Also added error logging by default.
